### PR TITLE
Separating unclassified and FASTQs with faulty barcodes from proper FASTQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The pipeline consists of a single workflow that processes Nanopore POD5 files th
 The workflow produces the following outputs:
 
 1. `raw/`: Directory containing the final FASTQ files
-2. `summary/`: Directory containing basecalling summary statistics
+2. `unclassified/`: Directory containing unclassified FASTQ files (only relevant for demultiplexing)
 
 ## Using the Workflow
 
@@ -40,12 +40,17 @@ Create a new directory, name it after the delivery, copy in basecall.config as n
   - Demultiplex basecalling output?
 - nanopore_run
   - Name of run/delivery
-- kit 
+- kit
   - Name of ONT kit, needed for demux'ing
-- pod_5_dir
-  - path to dir containing pod5 files
-- base_dir
-  - path to where output will be saved to
+
+Additionally, add a barcodes.txt file to the directory, containing the barcodes to be demultiplexed, in the format:
+
+```
+01
+02
+12
+...
+```
 
 Once that is done, you can switch into the directory and run
 

--- a/configs/basecall.config
+++ b/configs/basecall.config
@@ -13,6 +13,9 @@ params {
     // Delivery
     nanopore_run = <NANOPORE_RUN> // format: "NAO-ONT-YYYYMMDD-LIBRARY"
 
+    // Barcodes
+    barcodes = "${launchDir}/barcodes.tsv"
+
     // Directories
     pod_5_dir = "s3://nao-restricted/${nanopore_run}/pod5/*"
     base_dir = "s3://<PERSONAL_S3_BUCKET>/${nanopore_run}" // Parent for working and output directories (can be S3)

--- a/configs/containers.config
+++ b/configs/containers.config
@@ -9,8 +9,8 @@ process {
         // NB: As of 2024-07-01, no more specific tag available
     }
     withLabel: dorado {
-        container = "ontresearch/dorado:latest"
-        // NB: For now going with latest version, maybe the version switching with new updates will break things in the future.
+        container = "ontresearch/dorado:sha3d64678bdcbb70971ee56891c01b9902eab9deea"
+        // v0.9.1
     }
     withLabel: samtools {
         container = "staphb/samtools:latest"

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -85,6 +85,9 @@ process DEMUX_POD_5 {
         # Print contents of demultiplexed directory
         ls -la demultiplexed/*
 
+        # Create unclassified file if it doesn't exist
+        touch demultiplexed/${nanopore_run}-unclassified-${division}.bam
+
         # Rename output files
         for f in demultiplexed/*; do
             # Extract demux_id from filename
@@ -96,13 +99,9 @@ process DEMUX_POD_5 {
                 echo "Processing file: $f with Demux ID: ${demux_id}"
                 mv "$f" "demultiplexed/${nanopore_run}-${demux_id}-${division}.bam"
             else
-                if [ -f "demultiplexed/${nanopore_run}-unclassified-${division}.bam" ]; then
-                    # Append to existing unclassified file
-                    cat "$f" >> "demultiplexed/${nanopore_run}-unclassified-${division}.bam"
-                else
-                    # Create new unclassified file
-                    cp "$f" "demultiplexed/${nanopore_run}-unclassified-${division}.bam"
-                fi
+                # Append to unclassified file and remove
+                cat "$f" >> "demultiplexed/${nanopore_run}-unclassified-${division}.bam"
+                rm "$f"
             fi
         done
         '''

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -65,6 +65,7 @@ process DEMUX_POD_5 {
         val valid_barcodes
     output:
         path('demultiplexed/*'), emit: demux_bam
+        path('unclassified/*'), emit: unclassified_bam
 
     shell:
         '''
@@ -86,7 +87,8 @@ process DEMUX_POD_5 {
         ls -la demultiplexed/*
 
         # Create unclassified file if it doesn't exist
-        touch demultiplexed/${nanopore_run}-unclassified-${division}.bam
+        mkdir -p unclassified
+        touch unclassified/${nanopore_run}-unclassified-${division}.bam
 
         # Rename output files
         for f in demultiplexed/*; do
@@ -100,10 +102,10 @@ process DEMUX_POD_5 {
                 mv "$f" "demultiplexed/${nanopore_run}-${demux_id}-${division}.bam"
             elif [[ "$f" == *"unclassified"* ]]; then
                 echo "Processing unclassified file: $f"
-                mv "$f" "demultiplexed/${nanopore_run}-unclassified-${division}.bam"
+                mv "$f" "unclassified/${nanopore_run}-unclassified-${division}.bam"
             else
                 echo "Processing wrong barcode file: $f"
-                mv "$f" "demultiplexed/${nanopore_run}-wrong-barcode-${division}.bam"
+                mv "$f" "unclassified/${nanopore_run}-faulty-barcode-${demux_id}-${division}.bam"
             fi
         done
         '''

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -77,18 +77,11 @@ process DEMUX_POD_5 {
         # Turn the barcodes into a proper array by removing brackets and splitting on comma
         barcodes_array=($(echo "$barcodes" | tr -d '[]' | tr ',' ' '))
 
-        echo "Barcodes: !{valid_barcodes}"
-        echo "Barcodes array: ${barcodes_array[@]}"
-
         # Demultiplex
         dorado demux --no-classify --output-dir demultiplexed/ !{bam}
 
-        # Print contents of demultiplexed directory
-        ls -la demultiplexed/*
-
-        # Create unclassified file if it doesn't exist
+        # Create unclassified dir
         mkdir -p unclassified
-        touch unclassified/${nanopore_run}-unclassified-${division}.bam
 
         # Rename output files
         for f in demultiplexed/*; do
@@ -104,7 +97,7 @@ process DEMUX_POD_5 {
                 echo "Processing unclassified file: $f"
                 mv "$f" "unclassified/${nanopore_run}-unclassified-${division}.bam"
             else
-                echo "Processing wrong barcode file: $f"
+                echo "Processing wrong barcode: $f"
                 mv "$f" "unclassified/${nanopore_run}-faulty-barcode-${demux_id}-${division}.bam"
             fi
         done

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -98,10 +98,12 @@ process DEMUX_POD_5 {
             if [[ " ${barcodes_array[@]} " =~ " ${demux_id} " ]]; then
                 echo "Processing file: $f with Demux ID: ${demux_id}"
                 mv "$f" "demultiplexed/${nanopore_run}-${demux_id}-${division}.bam"
+            elif [[ "$f" == *"unclassified"* ]]; then
+                echo "Processing unclassified file: $f"
+                mv "$f" "demultiplexed/${nanopore_run}-unclassified-${division}.bam"
             else
-                # Append to unclassified file and remove
-                cat "$f" >> "demultiplexed/${nanopore_run}-unclassified-${division}.bam"
-                rm "$f"
+                echo "Processing wrong barcode file: $f"
+                mv "$f" "demultiplexed/${nanopore_run}-wrong-barcode-${division}.bam"
             fi
         done
         '''

--- a/modules/local/samtools/main.nf
+++ b/modules/local/samtools/main.nf
@@ -24,7 +24,7 @@ process MERGE_BAMS {
         path(bam_files)
         val nanopore_run
     output:
-        path('!{nanopore_run}-unclassified.bam')
+        path("${nanopore_run}-unclassified.bam")
     shell:
         '''
         samtools merge -r -o !{nanopore_run}-unclassified.bam !{bam_files}

--- a/modules/local/samtools/main.nf
+++ b/modules/local/samtools/main.nf
@@ -16,3 +16,17 @@ process BAM_TO_FASTQ {
         samtools fastq !{bam} | gzip -c > "${base_name}.fastq.gz"
         '''
 }
+
+process MERGE_BAMS {
+    label "samtools"
+
+    input:
+        path(bam_files)
+        val nanopore_run
+    output:
+        path('!{nanopore_run}-unclassified.bam')
+    shell:
+        '''
+        samtools merge -r -o !{nanopore_run}-unclassified.bam !{bam_files}
+        '''
+}

--- a/workflows/basecall.nf
+++ b/workflows/basecall.nf
@@ -50,7 +50,7 @@ workflow BASECALL {
         if (params.demux) {
             demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
             classified_bam_ch = demux_ch.demux_bam.flatten()
-            unclassified_bam_ch = MERGE_BAMS(demux_ch.unclassified_bam, params.nanopore_run)
+            unclassified_bam_ch = MERGE_BAMS(demux_ch.unclassified_bam.collect(), params.nanopore_run)
             final_bam_ch = classified_bam_ch.mix(unclassified_bam_ch)
         }
     }

--- a/workflows/basecall.nf
+++ b/workflows/basecall.nf
@@ -12,8 +12,8 @@ import java.time.LocalDateTime
 include { BASECALL_POD_5_SIMPLEX } from "../modules/local/dorado"
 include { BASECALL_POD_5_DUPLEX } from "../modules/local/dorado"
 include { DEMUX_POD_5 } from "../modules/local/dorado"
-include { BAM_TO_FASTQ as BAM_TO_FASTQ_DEMUX } from "../modules/local/samtools"
-include { BAM_TO_FASTQ as BAM_TO_FASTQ_UNCLASSIFIED } from "../modules/local/samtools"
+include { BAM_TO_FASTQ } from "../modules/local/samtools"
+include { MERGE_BAMS } from "../modules/local/samtools"
 nextflow.preview.output = true
 
 /*****************
@@ -49,16 +49,15 @@ workflow BASECALL {
         bam_ch = BASECALL_POD_5_SIMPLEX(pod5_ch, params.kit, params.nanopore_run)
         if (params.demux) {
             demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
-            final_bam_ch = demux_ch.demux_bam.flatten()
-            unclassified_bam_ch = demux_ch.unclassified_bam.flatten()
+            classified_bam_ch = demux_ch.demux_bam.flatten()
+            unclassified_bam_ch = MERGE_BAMS(demux_ch.unclassified_bam, params.nanopore_run)
+            final_bam_ch = classified_bam_ch.mix(unclassified_bam_ch)
         }
     }
 
     // Convert to FASTQ
-    classified_fastq_ch = BAM_TO_FASTQ_DEMUX(final_bam_ch, params.nanopore_run)
-    unclassified_fastq_ch = BAM_TO_FASTQ_UNCLASSIFIED(unclassified_bam_ch, params.nanopore_run)
+    fastq_ch = BAM_TO_FASTQ(final_bam_ch, params.nanopore_run)
 
     publish:
-        classified_fastq_ch >> "raw"
-        unclassified_fastq_ch >> "unclassified"
+        fastq_ch >> "raw"
 }

--- a/workflows/basecall.nf
+++ b/workflows/basecall.nf
@@ -37,6 +37,9 @@ workflow BASECALL {
         }
     }
 
+    // Barcodes
+    barcodes_ch = file(params.barcodes).readLines().collect()
+
     // Basecalling
     if (params.duplex) {
         bam_ch = BASECALL_POD_5_DUPLEX(pod5_ch, params.kit, params.nanopore_run)
@@ -44,7 +47,7 @@ workflow BASECALL {
     } else {
         bam_ch = BASECALL_POD_5_SIMPLEX(pod5_ch, params.kit, params.nanopore_run)
         if (params.demux) {
-            demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run)
+            demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
             final_bam_ch = demux_ch.demux_bam.flatten()
         }
     }


### PR DESCRIPTION
In addition to properly basecalled FASTQs, the basecalling process generates files containing unclassified reads and small files with faulty barcodes. These files can interfere with the mgs-workflow pipeline (and are misleading in case of the faulty barcode files).

To address this, I've introduced barcode validation using a user-generated `barcodes.tsv` file. Files identified with faulty or unclassified barcodes are merged into one unclassified file.