### PR TITLE
Increase dorado memory from 16GB to 30GB to fix OOM errors

### DIFF
--- a/configs/resources.config
+++ b/configs/resources.config
@@ -23,4 +23,17 @@ process {
         cpus = 32
         memory = 64.GB
     }
+
+    // GPU basecalling processes (g5.2xlarge: 32 GB RAM, 1 GPU)
+    withLabel: basecall {
+        cpus = 8
+        memory = 30.GB
+    }
+
+    // GPU demultiplexing processes (g5.2xlarge: 32 GB RAM, 1 GPU)
+    withLabel: demux {
+        cpus = 8
+        memory = 30.GB
+    }
 }
+

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -3,7 +3,6 @@ process BASECALL_POD_5_SIMPLEX {
     label "dorado"
     label "basecall"
     accelerator 1
-    memory '16 GB'
 
     input:
         tuple path(pod5), val(division)
@@ -29,7 +28,6 @@ process BASECALL_POD_5_DUPLEX {
     label "dorado"
     label "basecall"
     accelerator 1
-    memory '16 GB'
 
     input:
         tuple path(pod5), val(division)
@@ -56,7 +54,6 @@ process DEMUX_POD_5 {
     label "dorado"
     label "demux"
     accelerator 1
-    memory '16 GB'
 
     input:
         tuple path(bam), val(division)


### PR DESCRIPTION
Alessandro reports success with requiring 30G (see the Linear ticket), so we infer the 2G memory overhead is sufficient.