### PR TITLE
Merge classified BAMs by barcode before FASTQ conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ The pipeline consists of a single workflow that processes Nanopore POD5 files th
 
 ### Pipeline Outputs
 
-The workflow produces the following outputs:
+All output FASTQs are published to a single `raw/` directory.
 
-1. `raw/`: Directory containing the final FASTQ files
-2. `unclassified/`: Directory containing unclassified FASTQ files (only relevant for demultiplexing)
+When `demux = true`, the directory contains one FASTQ per barcode listed in `barcodes.txt`, plus one for unclassified reads:
+
+- `${nanopore_run}-${barcode}_SE.fastq.gz` (e.g., `${nanopore_run}-01_SE.fastq.gz`)
+- `${nanopore_run}-unclassified_SE.fastq.gz` (also includes reads that dorado tagged with a barcode not in `barcodes.txt`)
 
 ## Using the Workflow
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ When `demux = true`, the directory contains one FASTQ per barcode listed in `bar
 - `${nanopore_run}-${barcode}_SE.fastq.gz` (e.g., `${nanopore_run}-01_SE.fastq.gz`)
 - `${nanopore_run}-unclassified_SE.fastq.gz` (also includes reads that dorado tagged with a barcode not in `barcodes.txt`)
 
+The `_SE` suffix denotes single-end reads, distinguishing these files from the `_R1` / `_R2` suffix convention used for paired-end reads.
+
 ## Using the Workflow
 
 ### Installation & Setup

--- a/main.nf
+++ b/main.nf
@@ -62,7 +62,7 @@ workflow {
                 .groupTuple()
 
             unclassified_grouped_ch = demux_ch.unclassified_bam.collect()
-                .map { files -> tuple("${params.nanopore_run}-unclassified", files) }
+                .map { files -> tuple("${params.nanopore_run}-unclassified_SE", files) }
 
             final_bam_ch = MERGE_BAMS(classified_grouped_ch.mix(unclassified_grouped_ch))
         }

--- a/main.nf
+++ b/main.nf
@@ -40,12 +40,12 @@ workflow {
 
     // Basecalling
     if (params.duplex) {
-        bam_ch = BASECALL_POD_5_DUPLEX(pod5_ch, params.kit, params.nanopore_run)
+        bam_ch = BASECALL_POD_5_DUPLEX(pod5_ch, params.nanopore_run)
         final_bam_ch = bam_ch.bam.flatten()
     } else {
         bam_ch = BASECALL_POD_5_SIMPLEX(pod5_ch, params.kit, params.nanopore_run)
         if (params.demux) {
-            demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
+            demux_ch = DEMUX_POD_5(bam_ch.bam, params.nanopore_run, barcodes_ch)
 
             // Each BAM's parent directory name is its merge key, set by DEMUX_POD_5.
             merge_input_ch = demux_ch.demux_bam.flatten()

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,6 @@
 
 import groovy.json.JsonOutput
 import java.time.LocalDateTime
-import java.util.regex.Pattern
 
 /***************************
 | MODULES AND SUBWORKFLOWS |
@@ -51,23 +50,13 @@ workflow {
         if (params.demux) {
             demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
 
-            // Group classified BAMs by barcode.
-            // Filename pattern from DEMUX_POD_5: "${nanopore_run}-${barcode}-divNNNN.bam"
-            // Pattern.quote shields against any regex metachars in the run name.
-            run_prefix_re = "^${Pattern.quote(params.nanopore_run + '-')}"
-            classified_grouped_ch = demux_ch.demux_bam.flatten()
-                .map { bam ->
-                    def barcode = bam.baseName
-                        .replaceFirst(run_prefix_re, '')
-                        .replaceFirst(/-div\d{4}$/, '')
-                    tuple("${params.nanopore_run}-${barcode}_SE", bam)
-                }
+            // DEMUX_POD_5 stages each BAM under `demux_out/${merge_key}/`,
+            // so the parent directory name is the merge key — no filename parsing.
+            merge_input_ch = demux_ch.demux_bam.flatten()
+                .map { bam -> tuple("${params.nanopore_run}-${bam.parent.name}_SE", bam) }
                 .groupTuple()
 
-            unclassified_grouped_ch = demux_ch.unclassified_bam.collect()
-                .map { files -> tuple("${params.nanopore_run}-unclassified_SE", files) }
-
-            final_bam_ch = MERGE_BAMS(classified_grouped_ch.mix(unclassified_grouped_ch))
+            final_bam_ch = MERGE_BAMS(merge_input_ch)
         }
     }
 

--- a/main.nf
+++ b/main.nf
@@ -47,8 +47,7 @@ workflow {
         if (params.demux) {
             demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
 
-            // DEMUX_POD_5 stages each BAM under `demux_out/${merge_key}/`,
-            // so the parent directory name is the merge key — no filename parsing.
+            // Each BAM's parent directory name is its merge key, set by DEMUX_POD_5.
             merge_input_ch = demux_ch.demux_bam.flatten()
                 .map { bam -> tuple("${params.nanopore_run}-${bam.parent.name}_SE", bam) }
                 .groupTuple()

--- a/main.nf
+++ b/main.nf
@@ -4,6 +4,7 @@
 
 import groovy.json.JsonOutput
 import java.time.LocalDateTime
+import java.util.regex.Pattern
 
 /***************************
 | MODULES AND SUBWORKFLOWS |
@@ -52,10 +53,12 @@ workflow {
 
             // Group classified BAMs by barcode.
             // Filename pattern from DEMUX_POD_5: "${nanopore_run}-${barcode}-divNNNN.bam"
+            // Pattern.quote shields against any regex metachars in the run name.
+            run_prefix_re = "^${Pattern.quote(params.nanopore_run + '-')}"
             classified_grouped_ch = demux_ch.demux_bam.flatten()
                 .map { bam ->
                     def barcode = bam.baseName
-                        .replaceFirst(/^${params.nanopore_run}-/, '')
+                        .replaceFirst(run_prefix_re, '')
                         .replaceFirst(/-div\d{4}$/, '')
                     tuple("${params.nanopore_run}-${barcode}_SE", bam)
                 }

--- a/main.nf
+++ b/main.nf
@@ -49,9 +49,22 @@ workflow {
         bam_ch = BASECALL_POD_5_SIMPLEX(pod5_ch, params.kit, params.nanopore_run)
         if (params.demux) {
             demux_ch = DEMUX_POD_5(bam_ch.bam, params.kit, params.nanopore_run, barcodes_ch)
-            classified_bam_ch = demux_ch.demux_bam.flatten()
-            unclassified_bam_ch = MERGE_BAMS(demux_ch.unclassified_bam.collect(), params.nanopore_run)
-            final_bam_ch = classified_bam_ch.mix(unclassified_bam_ch)
+
+            // Group classified BAMs by barcode.
+            // Filename pattern from DEMUX_POD_5: "${nanopore_run}-${barcode}-divNNNN.bam"
+            classified_grouped_ch = demux_ch.demux_bam.flatten()
+                .map { bam ->
+                    def barcode = bam.baseName
+                        .replaceFirst(/^${params.nanopore_run}-/, '')
+                        .replaceFirst(/-div\d{4}$/, '')
+                    tuple("${params.nanopore_run}-${barcode}_SE", bam)
+                }
+                .groupTuple()
+
+            unclassified_grouped_ch = demux_ch.unclassified_bam.collect()
+                .map { files -> tuple("${params.nanopore_run}-unclassified", files) }
+
+            final_bam_ch = MERGE_BAMS(classified_grouped_ch.mix(unclassified_grouped_ch))
         }
     }
 

--- a/main.nf
+++ b/main.nf
@@ -2,9 +2,6 @@
 | WORKFLOW: BASECALLING NANOPORE SQUIGGLE DATA |
 ***********************************************************************************************/
 
-import groovy.json.JsonOutput
-import java.time.LocalDateTime
-
 /***************************
 | MODULES AND SUBWORKFLOWS |
 ***************************/
@@ -61,7 +58,7 @@ workflow {
     }
 
     // Convert to FASTQ
-    fastq_ch = BAM_TO_FASTQ(final_bam_ch, params.nanopore_run)
+    fastq_ch = BAM_TO_FASTQ(final_bam_ch)
 
     publish:
         fastq_ch = fastq_ch

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -61,8 +61,10 @@ process DEMUX_POD_5 {
         val nanopore_run
         val valid_barcodes
     output:
-        path('demultiplexed/*'), emit: demux_bam, optional: true
-        path('unclassified/*'), emit: unclassified_bam, optional: true
+        // Parent directory is the merge key for downstream groupTuple:
+        // per-barcode dirs for valid barcodes, plus an `unclassified/` dir
+        // that absorbs both true-unclassified and faulty-barcode reads.
+        path('demux_out/*/*.bam'), emit: demux_bam, optional: true
 
     shell:
         '''
@@ -73,35 +75,38 @@ process DEMUX_POD_5 {
 
         # Turn the barcodes into a proper array by removing brackets and splitting on comma
         barcodes_array=($(echo "$barcodes" | tr -d '[]' | tr ',' ' '))
-        
-        # Create unclassified and demultiplexed dirs
-        mkdir -p unclassified
-        mkdir -p demultiplexed
+
+        mkdir -p tmp_demux
 
         # Demultiplex
-        dorado demux --no-classify --output-dir demultiplexed/ !{bam}
+        dorado demux --no-classify --output-dir tmp_demux/ !{bam}
 
-        # Rename output files
-        if [ "$(ls -A demultiplexed/)" ]; then
-            for f in demultiplexed/*; do
-                # Extract demux_id from filename
+        if [ "$(ls -A tmp_demux/)" ]; then
+            for f in tmp_demux/*.bam; do
                 demux_id=$(basename "$f" .bam | awk -F '_' '{print $NF}')
                 demux_id=${demux_id#barcode}
 
-                # Check if demux_id is in valid_barcodes
                 if [[ " ${barcodes_array[@]} " =~ " ${demux_id} " ]]; then
                     echo "Processing file: $f with Demux ID: ${demux_id}"
-                    mv "$f" "demultiplexed/${nanopore_run}-${demux_id}-${division}.bam"
+                    merge_key="${demux_id}"
+                    new_name="${nanopore_run}-${demux_id}-${division}.bam"
                 elif [[ "$f" == *"unclassified"* ]]; then
                     echo "Processing unclassified file: $f"
-                    mv "$f" "unclassified/${nanopore_run}-unclassified-${division}.bam"
+                    merge_key="unclassified"
+                    new_name="${nanopore_run}-unclassified-${division}.bam"
                 else
                     echo "Processing wrong barcode: $f"
-                    mv "$f" "unclassified/${nanopore_run}-faulty-barcode-${demux_id}-${division}.bam"
+                    merge_key="unclassified"
+                    new_name="${nanopore_run}-faulty-barcode-${demux_id}-${division}.bam"
                 fi
+
+                mkdir -p "demux_out/${merge_key}"
+                mv "$f" "demux_out/${merge_key}/${new_name}"
             done
         else
-            echo "No files to process in demultiplexed/"
+            echo "No files to process in tmp_demux/"
         fi
+
+        rmdir tmp_demux 2>/dev/null || true
         '''
 }

--- a/modules/local/dorado/main.nf
+++ b/modules/local/dorado/main.nf
@@ -31,7 +31,6 @@ process BASECALL_POD_5_DUPLEX {
 
     input:
         tuple path(pod5), val(division)
-        val kit
         val nanopore_run
 
     output:
@@ -57,7 +56,6 @@ process DEMUX_POD_5 {
 
     input:
         tuple path(bam), val(division)
-        val kit
         val nanopore_run
         val valid_barcodes
     output:

--- a/modules/local/samtools/main.nf
+++ b/modules/local/samtools/main.nf
@@ -21,12 +21,11 @@ process MERGE_BAMS {
     label "samtools"
 
     input:
-        path(bam_files)
-        val nanopore_run
+        tuple val(out_name), path(bam_files)
     output:
-        path("${nanopore_run}-unclassified.bam")
+        path("${out_name}.bam")
     shell:
         '''
-        samtools merge -r -o !{nanopore_run}-unclassified.bam !{bam_files}
+        samtools merge -r -o !{out_name}.bam !{bam_files}
         '''
 }

--- a/modules/local/samtools/main.nf
+++ b/modules/local/samtools/main.nf
@@ -3,7 +3,6 @@ process BAM_TO_FASTQ {
 
     input:
         path(bam)
-        val nanopore_run
     output:
         path '*.fastq.gz'
 


### PR DESCRIPTION
Merge the `div` files into one big fastq per sample. Don't merge before:
1. https://github.com/securebio/nao-mgs-import/pull/68 (updates samplesheet creation)
2. The next release of `mgs-workflow`, which brings the nextflow configuration changes online.
3. Warning Alessandro to use the lastest `mgs-workflow` when processing new deliveries.

---
[Claude from here]

## Summary

- After `DEMUX_POD_5` runs, group its per-division BAMs by barcode and merge each group with `samtools merge` before `BAM_TO_FASTQ`. Reduces published FASTQ count from `divs × barcodes + 1` (e.g., 2,272 for a recent library) to one file per barcode plus one unclassified.
- `DEMUX_POD_5` writes each renamed BAM into `demux_out/${merge_key}/`, where the merge key is the barcode (e.g. `01`) for valid demuxes and `unclassified` for both true-unclassified and faulty-barcode reads. Faulty-barcode files still encode their dorado-reported id in the BAM filename for forensics. `main.nf` reads the merge key as `bam.parent.name`, so the channel logic is a single `.map` + `groupTuple`. No filename parsing, no regex over the user-controlled run name.
- `MERGE_BAMS` takes a `(out_name, bam_files)` tuple so the caller owns the published-artifact naming convention. All FASTQs use the delivery-wide `_SE` suffix:
  - Classified: `${nanopore_run}-${barcode}_SE.fastq.gz`
  - Unclassified: `${nanopore_run}-unclassified_SE.fastq.gz` (also includes reads dorado tagged with a barcode not in `barcodes.txt`)
- Dead-code cleanup: dropped the unused `kit` input from `DEMUX_POD_5` and `BASECALL_POD_5_DUPLEX` (only `BASECALL_POD_5_SIMPLEX` passes `--kit-name` to dorado).

Closes #19.
Closes #21.

## Test plan

Verified locally with synthetic data — no production buckets touched, no GPU basecalling needed.

- [x] **End-to-end merge+convert against fabricated BAMs.** Generated 12 synthetic per-division BAMs (3 valid barcodes × 3 divs + 2 unclassified + 1 faulty-barcode) via `samtools view -bh`, staged them in the `demux_out/<key>/` layout that `DEMUX_POD_5` produces, and ran `MERGE_BAMS` + `BAM_TO_FASTQ` against them via a stub harness workflow under `-profile ec2_local`. Used an adversarial run name (`NAO.ONT-20260430+test`, regex metacharacters `.` and `+`) to confirm the workflow no longer cares about characters in `nanopore_run`. Verified:
  - Exactly one `${run}-${barcode}_SE.fastq.gz` per valid barcode + one `${run}-unclassified_SE.fastq.gz`. No per-division files leak through.
  - Read counts match exactly: `01` 12, `02` 9, `12` 6, `unclassified` 13 (= 5 + 5 + 3 from the faulty-barcode file).
  - Read-name set on each merged FASTQ equals the union of read names on the per-division inputs (no drops, no duplicates).
- [x] **`-resume` correctness** — second run cached all merge + convert tasks.
- [x] **Regression read-through** — duplex branch (`params.duplex = true`) never enters the demux path; the `BASECALL_POD_5_DUPLEX` signature change is a mechanical drop of the unused `kit` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)