### PR TITLE
Add head-container entrypoint for ONT basecalling automation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,15 +40,17 @@ jobs:
           docker run --rm --entrypoint /usr/local/bin/_entrypoint.sh
           basecall-workflow-test python -m seq_import --help
 
-      - name: Smoke test - entrypoint validates required env vars
+      - name: Smoke test - entrypoint validates required args
         run: |
           output=$(docker run --rm basecall-workflow-test 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q DELIVERY
+          echo "$output" | grep -q -- --delivery
 
-      - name: Smoke test - entrypoint rejects bad DELIVERY
+      - name: Smoke test - entrypoint rejects bad --delivery
         run: |
-          ! docker run --rm \
-            -e DELIVERY='../etc' -e KIT=SQK-RPB114-24 -e AWS_QUEUE=q \
-            -e BASE_BUCKET=nao-restricted -e WORK_BUCKET=sb-det-ont-basecall-work \
-            basecall-workflow-test
+          ! docker run --rm basecall-workflow-test \
+            --delivery ../etc \
+            --kit SQK-RPB114-24 \
+            --aws-queue q \
+            --base-bucket nao-restricted \
+            --work-bucket sb-det-ont-basecall-work

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,12 +35,20 @@ jobs:
           docker run --rm --entrypoint /usr/local/bin/_entrypoint.sh basecall-workflow-test
           bash -c "cd /tmp && nextflow config /workflow/main.nf > /dev/null && test -d /workflow/configs"
 
-      - name: Smoke test - awscli available
-        run: >
-          docker run --rm --entrypoint /usr/local/bin/_entrypoint.sh
-          basecall-workflow-test aws --version
-
       - name: Smoke test - seq_import entry point
         run: >
           docker run --rm --entrypoint /usr/local/bin/_entrypoint.sh
           basecall-workflow-test python -m seq_import --help
+
+      - name: Smoke test - entrypoint validates required env vars
+        run: |
+          output=$(docker run --rm basecall-workflow-test 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q DELIVERY
+
+      - name: Smoke test - entrypoint rejects bad DELIVERY
+        run: |
+          ! docker run --rm \
+            -e DELIVERY='../etc' -e KIT=SQK-RPB114-24 -e AWS_QUEUE=q \
+            -e BASE_BUCKET=nao-restricted -e WORK_BUCKET=sb-det-ont-basecall-work \
+            basecall-workflow-test

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,12 +45,3 @@ jobs:
           output=$(docker run --rm basecall-workflow-test 2>&1 || true)
           echo "$output"
           echo "$output" | grep -q -- --delivery
-
-      - name: Smoke test - entrypoint rejects bad --delivery
-        run: |
-          ! docker run --rm basecall-workflow-test \
-            --delivery ../etc \
-            --kit SQK-RPB114-24 \
-            --aws-queue q \
-            --base-bucket nao-restricted \
-            --work-bucket sb-det-ont-basecall-work

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,8 +43,15 @@ jobs:
 
       - name: Smoke test - entrypoint validates required args
         run: |
-          output=$(docker run --rm basecall-workflow-test 2>&1 || true)
+          set +e
+          output=$(docker run --rm basecall-workflow-test 2>&1)
+          exit_code=$?
+          set -e
           echo "$output"
+          if [ "$exit_code" -ne 2 ]; then
+            echo "Expected argparse exit code 2 for missing required args; got $exit_code"
+            exit 1
+          fi
           for flag in --delivery --kit --aws-queue --base-bucket --work-bucket; do
             echo "$output" | grep -q -- "$flag" || { echo "Missing required flag in error output: $flag"; exit 1; }
           done

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,10 +35,11 @@ jobs:
           docker run --rm --entrypoint /usr/local/bin/_entrypoint.sh basecall-workflow-test
           bash -c "cd /tmp && nextflow config /workflow/main.nf > /dev/null && test -d /workflow/configs"
 
-      - name: Smoke test - seq_import entry point
+      - name: Smoke test - seq_import samplesheet symbol
         run: >
           docker run --rm --entrypoint /usr/local/bin/_entrypoint.sh
-          basecall-workflow-test python -m seq_import --help
+          basecall-workflow-test python -c
+          "from seq_import.samplesheet import generate_samplesheet"
 
       - name: Smoke test - entrypoint validates required args
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,4 +44,6 @@ jobs:
         run: |
           output=$(docker run --rm basecall-workflow-test 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q -- --delivery
+          for flag in --delivery --kit --aws-queue --base-bucket --work-bucket; do
+            echo "$output" | grep -q -- "$flag" || { echo "Missing required flag in error output: $flag"; exit 1; }
+          done

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The image runs `python -m automation.run_automation`, which invokes `nextflow ru
 
 Required arguments (passed by the `startOntBasecall` Lambda via Batch `containerOverrides.command`):
 
-- `--delivery` — delivery name, e.g. `NAO-ONT-YYYYMMDD-LIBRARY` (must match `[A-Za-z0-9_-]+`)
+- `--delivery` — delivery name, e.g. `NAO-ONT-YYYYMMDD-LIBRARY`
 - `--kit` — ONT kit name, e.g. `SQK-RPB114-24`
 - `--aws-queue` — AWS Batch GPU queue for child basecalling jobs
 - `--base-bucket` — S3 bucket holding the delivery (`raw/`, `supplemental/`, `metadata/`)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `_SE` suffix denotes single-end reads, distinguishing these files from the `
 
 ### Installation & Setup
 
-1. Install Nextflow (23.04.0+)
+1. Install Nextflow (25.10+)
 2. Install Docker
 3. Set up [AWS BATCH](https://github.com/naobservatory/mgs-workflow/tree/master#:~:text=The%20batch%20profile%20is,your%20Batch%20job%20queue.)
 4. Clone this repository

--- a/README.md
+++ b/README.md
@@ -73,26 +73,25 @@ The `automation/` directory contains the head container that wraps this workflow
 
 ### Container entrypoint
 
-The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, runs `python -m seq_import samplesheet --delivery $DELIVERY` to write the samplesheet to `s3://$BASE_BUCKET/$DELIVERY/metadata/samplesheet.csv`.
+The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, runs `python -m seq_import samplesheet --delivery <delivery>` to write the samplesheet to `s3://<base-bucket>/<delivery>/metadata/samplesheet.csv`.
 
-Required environment variables (passed by the `startOntBasecall` Lambda via Batch `containerOverrides`):
+Required arguments (passed by the `startOntBasecall` Lambda via Batch `containerOverrides.command`):
 
-- `DELIVERY` — delivery name, e.g. `NAO-ONT-YYYYMMDD-LIBRARY` (must match `[A-Za-z0-9_-]+`)
-- `KIT` — ONT kit name, e.g. `SQK-RPB114-24`
-- `AWS_QUEUE` — AWS Batch GPU queue for child basecalling jobs
-- `BASE_BUCKET` — S3 bucket holding the delivery (`raw/`, `supplemental/`, `metadata/`)
-- `WORK_BUCKET` — S3 bucket for Nextflow's working directory
+- `--delivery` — delivery name, e.g. `NAO-ONT-YYYYMMDD-LIBRARY` (must match `[A-Za-z0-9_-]+`)
+- `--kit` — ONT kit name, e.g. `SQK-RPB114-24`
+- `--aws-queue` — AWS Batch GPU queue for child basecalling jobs
+- `--base-bucket` — S3 bucket holding the delivery (`raw/`, `supplemental/`, `metadata/`)
+- `--work-bucket` — S3 bucket for Nextflow's working directory
 
 Local smoke test:
 
 ```bash
-docker run --rm \
-  -e DELIVERY=NAO-ONT-YYYYMMDD-LIBRARY \
-  -e KIT=SQK-RPB114-24 \
-  -e AWS_QUEUE=<gpu-queue> \
-  -e BASE_BUCKET=nao-restricted \
-  -e WORK_BUCKET=sb-det-ont-basecall-work \
-  basecall-workflow
+docker run --rm basecall-workflow \
+  --delivery NAO-ONT-YYYYMMDD-LIBRARY \
+  --kit SQK-RPB114-24 \
+  --aws-queue <gpu-queue> \
+  --base-bucket nao-restricted \
+  --work-bucket sb-det-ont-basecall-work
 ```
 
 ### Build-time authentication

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `_SE` suffix denotes single-end reads, distinguishing these files from the `
 
 Basic usage:
 
-Create a new directory, name it after the delivery, copy in basecall.config as nextflow.config, and set the parameters. Params:
+Create a new directory, name it after the delivery, copy in basecall.config as nextflow.config, and set the parameters. Parameters left commented-out in `basecall.config` (marked `// fill ... and uncomment`) are the ones the caller must supply — uncomment and fill those before running. The non-commented params (`duplex`, `demux`, `mode`) have defaults that work for most runs. Params:
 
 - duplex
   - Duplex basecalling or no? You can't combine duplex and demux
@@ -73,7 +73,7 @@ The `automation/` directory contains the head container that wraps this workflow
 
 ### Container entrypoint
 
-The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, runs `python -m seq_import samplesheet --delivery <delivery> --bucket <base-bucket>` to write the samplesheet to `s3://<base-bucket>/<delivery>/metadata/samplesheet.csv`.
+The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, calls `seq_import.samplesheet.generate_samplesheet` in-process to write the samplesheet to `s3://<base-bucket>/<delivery>/metadata/samplesheet.csv`.
 
 Required arguments (passed by the `startOntBasecall` Lambda via Batch `containerOverrides.command`):
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ The `automation/` directory contains the head container that wraps this workflow
 - `.github/workflows/ecr-push.yml` — publishes the image to ECR on push to `main`
 - `.github/workflows/docker-build.yml` — PR-time build smoke test
 
+### Container entrypoint
+
+The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, runs `python -m seq_import samplesheet --delivery $DELIVERY` to write the samplesheet to `s3://$BASE_BUCKET/$DELIVERY/metadata/samplesheet.csv`.
+
+Required environment variables (passed by the `startOntBasecall` Lambda via Batch `containerOverrides`):
+
+- `DELIVERY` — delivery name, e.g. `NAO-ONT-YYYYMMDD-LIBRARY` (must match `[A-Za-z0-9_-]+`)
+- `KIT` — ONT kit name, e.g. `SQK-RPB114-24`
+- `AWS_QUEUE` — AWS Batch GPU queue for child basecalling jobs
+- `BASE_BUCKET` — S3 bucket holding the delivery (`raw/`, `supplemental/`, `metadata/`)
+- `WORK_BUCKET` — S3 bucket for Nextflow's working directory
+
+Local smoke test:
+
+```bash
+docker run --rm \
+  -e DELIVERY=NAO-ONT-YYYYMMDD-LIBRARY \
+  -e KIT=SQK-RPB114-24 \
+  -e AWS_QUEUE=<gpu-queue> \
+  -e BASE_BUCKET=nao-restricted \
+  -e WORK_BUCKET=sb-det-ont-basecall-work \
+  basecall-workflow
+```
+
 ### Build-time authentication
 
 Because the image pip-installs `seq_import` from the private `nao-mgs-import` repo, the build needs a GitHub token. CI mints a short-lived one via the `sbd-mgs-import-reader` GitHub App (App ID in `vars.IMPORT_READER_APP_ID`, private key in `secrets.IMPORT_READER_PRIVATE_KEY`) and passes it to `docker build` as a BuildKit secret, so it never lands in image layers. To build locally, supply any token with read access to `nao-mgs-import`:

--- a/README.md
+++ b/README.md
@@ -83,17 +83,6 @@ Required arguments (passed by the `startOntBasecall` Lambda via Batch `container
 - `--base-bucket` — S3 bucket holding the delivery (`raw/`, `supplemental/`, `metadata/`)
 - `--work-bucket` — S3 bucket for Nextflow's working directory
 
-Local smoke test:
-
-```bash
-docker run --rm basecall-workflow \
-  --delivery NAO-ONT-YYYYMMDD-LIBRARY \
-  --kit SQK-RPB114-24 \
-  --aws-queue <gpu-queue> \
-  --base-bucket nao-restricted \
-  --work-bucket sb-det-ont-basecall-work
-```
-
 ### Build-time authentication
 
 Because the image pip-installs `seq_import` from the private `nao-mgs-import` repo, the build needs a GitHub token. CI mints a short-lived one via the `sbd-mgs-import-reader` GitHub App (App ID in `vars.IMPORT_READER_APP_ID`, private key in `secrets.IMPORT_READER_PRIVATE_KEY`) and passes it to `docker build` as a BuildKit secret, so it never lands in image layers. To build locally, supply any token with read access to `nao-mgs-import`:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `automation/` directory contains the head container that wraps this workflow
 
 ### Container entrypoint
 
-The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, runs `python -m seq_import samplesheet --delivery <delivery>` to write the samplesheet to `s3://<base-bucket>/<delivery>/metadata/samplesheet.csv`.
+The image runs `python -m automation.run_automation`, which invokes `nextflow run main.nf` against the AWS Batch GPU queue and, on success, runs `python -m seq_import samplesheet --delivery <delivery> --bucket <base-bucket>` to write the samplesheet to `s3://<base-bucket>/<delivery>/metadata/samplesheet.csv`.
 
 Required arguments (passed by the `startOntBasecall` Lambda via Batch `containerOverrides.command`):
 

--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -24,3 +24,6 @@ ARG BASECALL_WORKFLOW_COMMIT
 ENV BASECALL_WORKFLOW_COMMIT=$BASECALL_WORKFLOW_COMMIT
 
 USER mambauser
+
+COPY automation/__init__.py automation/run_automation.py /workflow/automation/
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "python", "-m", "automation.run_automation"]

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -1,15 +1,26 @@
 """Head-container entrypoint for the ONT basecalling automation.
 
-Invoked as `python -m automation.run_automation` by the Fargate Batch head job
-that the `startOntBasecall` Lambda submits when `supplemental/barcodes.tsv` is
-uploaded to a delivery prefix.
+Invoked as ``python -m automation.run_automation`` by the Fargate Batch head
+job that the ``startOntBasecall`` Lambda submits when a
+``supplemental/barcodes.tsv`` is uploaded to a delivery prefix.
+
+The wrapper:
+
+1. Reads required env vars set by the Lambda via Batch ``containerOverrides``.
+2. Validates ``DELIVERY`` against a conservative regex (defense in depth — the
+   Lambda also validates).
+3. Runs ``nextflow run main.nf -profile batch`` against the GPU queue.
+4. On success, runs ``python -m seq_import samplesheet --delivery $DELIVERY``
+   to write the samplesheet for downstream ``mgs-workflow`` ingestion.
+
+Both subprocesses use ``check=True``; any failure propagates a non-zero exit,
+which surfaces as a ``FAILED`` job in Batch with the traceback in CloudWatch.
 """
 
 import logging
 import os
 import re
 import subprocess
-import sys
 
 DUPLEX = "false"
 DEMUX = "true"
@@ -27,7 +38,8 @@ REQUIRED_ENV_VARS = (
 log = logging.getLogger(__name__)
 
 
-def load_env():
+def load_env() -> dict[str, str]:
+    """Read and validate required env vars; exit non-zero if any are missing or invalid."""
     missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
     if missing:
         raise SystemExit(
@@ -41,7 +53,19 @@ def load_env():
     return {v: os.environ[v] for v in REQUIRED_ENV_VARS}
 
 
-def build_nextflow_cmd(delivery, kit, aws_queue, base_bucket, work_bucket):
+def build_nextflow_cmd(
+    delivery: str,
+    kit: str,
+    aws_queue: str,
+    base_bucket: str,
+    work_bucket: str,
+) -> list[str]:
+    """Build the argv for ``nextflow run main.nf``.
+
+    Supplies every param left commented-out in ``configs/basecall.config`` as a
+    ``--<param>`` flag. ``-profile batch`` engages the AWS Batch executor +
+    Fusion FS settings in ``configs/profiles.config``.
+    """
     return [
         "nextflow", "run", "/workflow/main.nf",
         "-profile", "batch",
@@ -56,11 +80,17 @@ def build_nextflow_cmd(delivery, kit, aws_queue, base_bucket, work_bucket):
     ]
 
 
-def build_samplesheet_cmd(delivery):
+def build_samplesheet_cmd(delivery: str) -> list[str]:
+    """Build the argv for the ``seq_import samplesheet`` CLI.
+
+    ``seq_import`` defaults to ``--bucket nao-restricted``, which matches our
+    ``BASE_BUCKET``, so we don't pass ``--bucket`` explicitly — let seq_import
+    own that contract.
+    """
     return ["python", "-m", "seq_import", "samplesheet", "--delivery", delivery]
 
 
-def main():
+def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -8,10 +8,8 @@ The wrapper:
 
 1. Parses required CLI args supplied by the Lambda via Batch
    ``containerOverrides.command``.
-2. Validates ``--delivery`` against a conservative regex (defense in depth —
-   the Lambda also validates).
-3. Runs ``nextflow run main.nf -profile batch`` against the GPU queue.
-4. On success, runs ``python -m seq_import samplesheet --delivery <delivery>``
+2. Runs ``nextflow run main.nf -profile batch`` against the GPU queue.
+3. On success, runs ``python -m seq_import samplesheet --delivery <delivery>``
    to write the samplesheet for downstream ``mgs-workflow`` ingestion.
 
 Both subprocesses use ``check=True``; any failure propagates a non-zero exit,
@@ -20,24 +18,12 @@ which surfaces as a ``FAILED`` job in Batch with the traceback in CloudWatch.
 
 import argparse
 import logging
-import re
 import subprocess
 
 DUPLEX = "false"
 DEMUX = "true"
 
-DELIVERY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-
 log = logging.getLogger(__name__)
-
-
-def delivery_type(value: str) -> str:
-    """argparse type validator for ``--delivery``."""
-    if not DELIVERY_RE.match(value):
-        raise argparse.ArgumentTypeError(
-            f"{value!r} does not match {DELIVERY_RE.pattern}"
-        )
-    return value
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -47,8 +33,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Run basecall-workflow on a delivery, then emit its samplesheet.",
     )
     parser.add_argument(
-        "--delivery", type=delivery_type, required=True,
-        help="Delivery name, e.g. NAO-ONT-YYYYMMDD-LIBRARY (must match [A-Za-z0-9_-]+)",
+        "--delivery", required=True,
+        help="Delivery name, e.g. NAO-ONT-YYYYMMDD-LIBRARY",
     )
     parser.add_argument(
         "--kit", required=True,

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -9,7 +9,8 @@ The wrapper:
 1. Parses required CLI args supplied by the Lambda via Batch
    ``containerOverrides.command``.
 2. Runs ``nextflow run main.nf -profile batch`` against the GPU queue.
-3. On success, runs ``python -m seq_import samplesheet --delivery <delivery>``
+3. On success, runs
+   ``python -m seq_import samplesheet --delivery <delivery> --bucket <base-bucket>``
    to write the samplesheet for downstream ``mgs-workflow`` ingestion.
 
 Both subprocesses use ``check=True``; any failure propagates a non-zero exit,
@@ -19,9 +20,6 @@ which surfaces as a ``FAILED`` job in Batch with the traceback in CloudWatch.
 import argparse
 import logging
 import subprocess
-
-DUPLEX = "false"
-DEMUX = "true"
 
 log = logging.getLogger(__name__)
 
@@ -65,8 +63,9 @@ def build_nextflow_cmd(
     """Build the argv for ``nextflow run main.nf``.
 
     Supplies every param left commented-out in ``configs/basecall.config`` as a
-    ``--<param>`` flag. ``-profile batch`` engages the AWS Batch executor +
-    Fusion FS settings in ``configs/profiles.config``.
+    ``--<param>`` flag. ``duplex`` and ``demux`` are left to their config
+    defaults (``false`` / ``true``). ``-profile batch`` engages the AWS Batch
+    executor + Fusion FS settings in ``configs/profiles.config``.
     """
     return [
         "nextflow", "run", "/workflow/main.nf",
@@ -77,19 +76,21 @@ def build_nextflow_cmd(
         "--base_dir", f"s3://{base_bucket}/{delivery}",
         "--work_dir", f"s3://{work_bucket}/{delivery}",
         "--barcodes", f"s3://{base_bucket}/{delivery}/supplemental/barcodes.tsv",
-        "--duplex", DUPLEX,
-        "--demux", DEMUX,
     ]
 
 
-def build_samplesheet_cmd(delivery: str) -> list[str]:
+def build_samplesheet_cmd(delivery: str, base_bucket: str) -> list[str]:
     """Build the argv for the ``seq_import samplesheet`` CLI.
 
-    ``seq_import`` defaults to ``--bucket nao-restricted``, which matches our
-    ``--base-bucket``, so we don't pass ``--bucket`` explicitly — let
-    seq_import own that contract.
+    Forwards ``--base-bucket`` as ``seq_import``'s ``--bucket`` so the
+    samplesheet lands in the same bucket the workflow wrote ``raw/`` into,
+    regardless of seq_import's default.
     """
-    return ["python", "-m", "seq_import", "samplesheet", "--delivery", delivery]
+    return [
+        "python", "-m", "seq_import", "samplesheet",
+        "--delivery", delivery,
+        "--bucket", base_bucket,
+    ]
 
 
 def main() -> None:
@@ -109,7 +110,7 @@ def main() -> None:
     log.info("Running nextflow: %s", " ".join(nextflow_cmd))
     subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
 
-    samplesheet_cmd = build_samplesheet_cmd(args.delivery)
+    samplesheet_cmd = build_samplesheet_cmd(args.delivery, args.base_bucket)
     log.info("Generating samplesheet: %s", " ".join(samplesheet_cmd))
     subprocess.run(samplesheet_cmd, check=True)
 

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -1,0 +1,86 @@
+"""Head-container entrypoint for the ONT basecalling automation.
+
+Invoked as `python -m automation.run_automation` by the Fargate Batch head job
+that the `startOntBasecall` Lambda submits when `supplemental/barcodes.tsv` is
+uploaded to a delivery prefix.
+"""
+
+import logging
+import os
+import re
+import subprocess
+import sys
+
+DUPLEX = "false"
+DEMUX = "true"
+
+DELIVERY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+REQUIRED_ENV_VARS = (
+    "DELIVERY",
+    "KIT",
+    "AWS_QUEUE",
+    "BASE_BUCKET",
+    "WORK_BUCKET",
+)
+
+log = logging.getLogger(__name__)
+
+
+def load_env():
+    missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
+    if missing:
+        raise SystemExit(
+            f"Missing required environment variable(s): {', '.join(missing)}"
+        )
+    delivery = os.environ["DELIVERY"]
+    if not DELIVERY_RE.match(delivery):
+        raise SystemExit(
+            f"DELIVERY {delivery!r} does not match {DELIVERY_RE.pattern}"
+        )
+    return {v: os.environ[v] for v in REQUIRED_ENV_VARS}
+
+
+def build_nextflow_cmd(delivery, kit, aws_queue, base_bucket, work_bucket):
+    return [
+        "nextflow", "run", "/workflow/main.nf",
+        "-profile", "batch",
+        "--nanopore_run", delivery,
+        "--kit", kit,
+        "--aws_queue", aws_queue,
+        "--base_dir", f"s3://{base_bucket}/{delivery}",
+        "--work_dir", f"s3://{work_bucket}/{delivery}",
+        "--barcodes", f"s3://{base_bucket}/{delivery}/supplemental/barcodes.tsv",
+        "--duplex", DUPLEX,
+        "--demux", DEMUX,
+    ]
+
+
+def build_samplesheet_cmd(delivery):
+    return ["python", "-m", "seq_import", "samplesheet", "--delivery", delivery]
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    env = load_env()
+
+    nextflow_cmd = build_nextflow_cmd(
+        env["DELIVERY"],
+        env["KIT"],
+        env["AWS_QUEUE"],
+        env["BASE_BUCKET"],
+        env["WORK_BUCKET"],
+    )
+    log.info("Running nextflow: %s", " ".join(nextflow_cmd))
+    subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
+
+    samplesheet_cmd = build_samplesheet_cmd(env["DELIVERY"])
+    log.info("Generating samplesheet: %s", " ".join(samplesheet_cmd))
+    subprocess.run(samplesheet_cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -9,17 +9,21 @@ The wrapper:
 1. Parses required CLI args supplied by the Lambda via Batch
    ``containerOverrides.command``.
 2. Runs ``nextflow run main.nf -profile batch`` against the GPU queue.
-3. On success, runs
-   ``python -m seq_import samplesheet --delivery <delivery> --bucket <base-bucket>``
+3. On success, calls ``seq_import.samplesheet.generate_samplesheet`` in-process
    to write the samplesheet for downstream ``mgs-workflow`` ingestion.
 
-Both subprocesses use ``check=True``; any failure propagates a non-zero exit,
-which surfaces as a ``FAILED`` job in Batch with the traceback in CloudWatch.
+Nextflow runs with ``check=True``; any failure (subprocess or in-process)
+propagates a non-zero exit, which surfaces as a ``FAILED`` job in Batch with
+the traceback in CloudWatch.
 """
 
 import argparse
 import logging
 import subprocess
+
+import boto3
+from botocore.config import Config
+from seq_import.samplesheet import generate_samplesheet
 
 log = logging.getLogger(__name__)
 
@@ -62,10 +66,11 @@ def build_nextflow_cmd(
 ) -> list[str]:
     """Build the argv for ``nextflow run main.nf``.
 
-    Supplies every param left commented-out in ``configs/basecall.config`` as a
-    ``--<param>`` flag. ``duplex`` and ``demux`` are left to their config
-    defaults (``false`` / ``true``). ``-profile batch`` engages the AWS Batch
-    executor + Fusion FS settings in ``configs/profiles.config``.
+    Supplies every param that ``configs/basecall.config`` leaves for the caller
+    to provide (the commented-out lines tagged ``// fill ... and uncomment``).
+    ``duplex`` and ``demux`` are left to their config defaults (``false`` /
+    ``true``). ``-profile batch`` engages the AWS Batch executor + Fusion FS
+    settings in ``configs/profiles.config``.
     """
     return [
         "nextflow", "run", "/workflow/main.nf",
@@ -76,20 +81,6 @@ def build_nextflow_cmd(
         "--base_dir", f"s3://{base_bucket}/{delivery}",
         "--work_dir", f"s3://{work_bucket}/{delivery}",
         "--barcodes", f"s3://{base_bucket}/{delivery}/supplemental/barcodes.tsv",
-    ]
-
-
-def build_samplesheet_cmd(delivery: str, base_bucket: str) -> list[str]:
-    """Build the argv for the ``seq_import samplesheet`` CLI.
-
-    Forwards ``--base-bucket`` as ``seq_import``'s ``--bucket`` so the
-    samplesheet lands in the same bucket the workflow wrote ``raw/`` into,
-    regardless of seq_import's default.
-    """
-    return [
-        "python", "-m", "seq_import", "samplesheet",
-        "--delivery", delivery,
-        "--bucket", base_bucket,
     ]
 
 
@@ -110,9 +101,10 @@ def main() -> None:
     log.info("Running nextflow: %s", " ".join(nextflow_cmd))
     subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
 
-    samplesheet_cmd = build_samplesheet_cmd(args.delivery, args.base_bucket)
-    log.info("Generating samplesheet: %s", " ".join(samplesheet_cmd))
-    subprocess.run(samplesheet_cmd, check=True)
+    log.info("Generating samplesheet for delivery %s in bucket %s", args.delivery, args.base_bucket)
+    s3_client = boto3.client("s3", config=Config(max_pool_connections=50))
+    output_path = generate_samplesheet(s3_client, args.delivery, bucket=args.base_bucket)
+    log.info("Samplesheet written to: %s", output_path)
 
 
 if __name__ == "__main__":

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -6,19 +6,20 @@ job that the ``startOntBasecall`` Lambda submits when a
 
 The wrapper:
 
-1. Reads required env vars set by the Lambda via Batch ``containerOverrides``.
-2. Validates ``DELIVERY`` against a conservative regex (defense in depth — the
-   Lambda also validates).
+1. Parses required CLI args supplied by the Lambda via Batch
+   ``containerOverrides.command``.
+2. Validates ``--delivery`` against a conservative regex (defense in depth —
+   the Lambda also validates).
 3. Runs ``nextflow run main.nf -profile batch`` against the GPU queue.
-4. On success, runs ``python -m seq_import samplesheet --delivery $DELIVERY``
+4. On success, runs ``python -m seq_import samplesheet --delivery <delivery>``
    to write the samplesheet for downstream ``mgs-workflow`` ingestion.
 
 Both subprocesses use ``check=True``; any failure propagates a non-zero exit,
 which surfaces as a ``FAILED`` job in Batch with the traceback in CloudWatch.
 """
 
+import argparse
 import logging
-import os
 import re
 import subprocess
 
@@ -27,30 +28,45 @@ DEMUX = "true"
 
 DELIVERY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
-REQUIRED_ENV_VARS = (
-    "DELIVERY",
-    "KIT",
-    "AWS_QUEUE",
-    "BASE_BUCKET",
-    "WORK_BUCKET",
-)
-
 log = logging.getLogger(__name__)
 
 
-def load_env() -> dict[str, str]:
-    """Read and validate required env vars; exit non-zero if any are missing or invalid."""
-    missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
-    if missing:
-        raise SystemExit(
-            f"Missing required environment variable(s): {', '.join(missing)}"
+def delivery_type(value: str) -> str:
+    """argparse type validator for ``--delivery``."""
+    if not DELIVERY_RE.match(value):
+        raise argparse.ArgumentTypeError(
+            f"{value!r} does not match {DELIVERY_RE.pattern}"
         )
-    delivery = os.environ["DELIVERY"]
-    if not DELIVERY_RE.match(delivery):
-        raise SystemExit(
-            f"DELIVERY {delivery!r} does not match {DELIVERY_RE.pattern}"
-        )
-    return {v: os.environ[v] for v in REQUIRED_ENV_VARS}
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse the entrypoint's CLI args."""
+    parser = argparse.ArgumentParser(
+        prog="python -m automation.run_automation",
+        description="Run basecall-workflow on a delivery, then emit its samplesheet.",
+    )
+    parser.add_argument(
+        "--delivery", type=delivery_type, required=True,
+        help="Delivery name, e.g. NAO-ONT-YYYYMMDD-LIBRARY (must match [A-Za-z0-9_-]+)",
+    )
+    parser.add_argument(
+        "--kit", required=True,
+        help="ONT kit name, e.g. SQK-RPB114-24",
+    )
+    parser.add_argument(
+        "--aws-queue", required=True,
+        help="AWS Batch GPU queue for child basecalling jobs",
+    )
+    parser.add_argument(
+        "--base-bucket", required=True,
+        help="S3 bucket holding the delivery (raw/, supplemental/, metadata/)",
+    )
+    parser.add_argument(
+        "--work-bucket", required=True,
+        help="S3 bucket for Nextflow's working directory",
+    )
+    return parser.parse_args(argv)
 
 
 def build_nextflow_cmd(
@@ -84,8 +100,8 @@ def build_samplesheet_cmd(delivery: str) -> list[str]:
     """Build the argv for the ``seq_import samplesheet`` CLI.
 
     ``seq_import`` defaults to ``--bucket nao-restricted``, which matches our
-    ``BASE_BUCKET``, so we don't pass ``--bucket`` explicitly — let seq_import
-    own that contract.
+    ``--base-bucket``, so we don't pass ``--bucket`` explicitly — let
+    seq_import own that contract.
     """
     return ["python", "-m", "seq_import", "samplesheet", "--delivery", delivery]
 
@@ -95,19 +111,19 @@ def main() -> None:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
     )
-    env = load_env()
+    args = parse_args()
 
     nextflow_cmd = build_nextflow_cmd(
-        env["DELIVERY"],
-        env["KIT"],
-        env["AWS_QUEUE"],
-        env["BASE_BUCKET"],
-        env["WORK_BUCKET"],
+        args.delivery,
+        args.kit,
+        args.aws_queue,
+        args.base_bucket,
+        args.work_bucket,
     )
     log.info("Running nextflow: %s", " ".join(nextflow_cmd))
     subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
 
-    samplesheet_cmd = build_samplesheet_cmd(env["DELIVERY"])
+    samplesheet_cmd = build_samplesheet_cmd(args.delivery)
     log.info("Generating samplesheet: %s", " ".join(samplesheet_cmd))
     subprocess.run(samplesheet_cmd, check=True)
 

--- a/main.nf
+++ b/main.nf
@@ -11,7 +11,6 @@ include { BASECALL_POD_5_DUPLEX } from "./modules/local/dorado"
 include { DEMUX_POD_5 } from "./modules/local/dorado"
 include { BAM_TO_FASTQ } from "./modules/local/samtools"
 include { MERGE_BAMS } from "./modules/local/samtools"
-nextflow.preview.output = true
 
 /*****************
 | MAIN WORKFLOWS |


### PR DESCRIPTION
Again hopefully straightforward/following our usual automation patterns; adding our container entrypoint for the basecalling automation. 

Batched in a *tiny* change to update the workflow for nextflow 25 compatibility (this port had been 99% done back in June 2025, https://github.com/securebio/basecall-workflow/commit/7b8aaf9f9, I just now need to drop nextflow.preview.output = true for compatibility with current nextflow 25 versions.)  Tested that this runs end-to-end now with nextflow 25.10.04, the version pinned by automation). 

## Summary

- Adds `automation/run_automation.py` — the head-container entrypoint that takes `--delivery / --kit / --aws-queue / --base-bucket / --work-bucket` (passed by the `startOntBasecall` Lambda via Batch `containerOverrides.command`), runs `nextflow run main.nf -profile batch` with the six params left commented-out in `configs/basecall.config`, and on success calls `seq_import.samplesheet.generate_samplesheet` in-process to write the samplesheet for downstream `mgs-workflow` ingestion.
- Wires the image's `ENTRYPOINT` to `python -m automation.run_automation` via `/usr/local/bin/_entrypoint.sh` so the conda env (where `nextflow` and `python` live) activates before the wrapper runs.
- Updates CI smoke tests: drops the low-value `aws --version` check (awscli isn't on the runtime path — Nextflow uses Fusion FS, seq_import uses boto3), and adds one new test that exercises the entrypoint's argparse layer without needing AWS credentials.

This is the basecall-workflow side of PR 4 in the ONT basecalling automation port to `det-terraform-production`. The Dockerfile landed in #22 with no `ENTRYPOINT`; this PR makes the image actually do something when launched. The CLI-args shape (vs. env vars) was chosen to align with `startReadSizer`'s precedent, which `planOntBasecallingAutomation.md` says the new `startOntBasecall` Lambda will mirror.

## Test plan

- [x] `python -m automation.run_automation` with no args exits 2 listing all five required flags
- [x] `--help` documents every flag
- [x] `build_nextflow_cmd` produces the expected six `--<param>` flags + `-profile batch`
- [x] `mypy --strict automation/run_automation.py` passes clean
- [x] CI's docker-build job passes (build + three smoke tests)
- [ ] End-to-end smoke test from `planOntBasecallingAutomation.md` once the matching det-terraform-production PR lands: drop `supplemental/barcodes.tsv`, watch Lambda → head Fargate → child `nf-wave-*` jobs → `raw/` FASTQs + `metadata/samplesheet.csv` [this one needs to be after the PR lands]

## Notes for reviewer

- No `-resume` on the nextflow call: the Fargate head job is ephemeral and `.nextflow/` state doesn't survive container restarts, so `-resume` would silently do nothing on retry while adding log noise.
- The matching det-terraform-production PR should add `BASE_BUCKET` and `WORK_BUCKET` to `lambda/startOntBasecall/variables.tf` (or their CLI-flag equivalents — since this entrypoint takes CLI args, the Lambda will pass them via `containerOverrides.command`, but the per-environment infra values themselves still come from Terraform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
