### PR TITLE
Fix basecall.config path and publish .nextflow.log to LOG_BUCKET

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,6 +52,6 @@ jobs:
             echo "Expected argparse exit code 2 for missing required args; got $exit_code"
             exit 1
           fi
-          for flag in --delivery --kit --aws-queue --base-bucket --work-bucket; do
+          for flag in --delivery --kit --aws-queue --base-bucket --work-bucket --log-bucket; do
             echo "$output" | grep -q -- "$flag" || { echo "Missing required flag in error output: $flag"; exit 1; }
           done

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Required arguments (passed by the `startOntBasecall` Lambda via Batch `container
 - `--aws-queue` — AWS Batch GPU queue for child basecalling jobs
 - `--base-bucket` — S3 bucket holding the delivery (`raw/`, `supplemental/`, `metadata/`)
 - `--work-bucket` — S3 bucket for Nextflow's working directory
+- `--log-bucket` — S3 bucket for publishing `.nextflow.log` after the run
 
 ### Build-time authentication
 

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -18,11 +18,14 @@ the traceback in CloudWatch.
 """
 
 import argparse
+import datetime as dt
 import logging
 import subprocess
+from pathlib import Path
 
 import boto3
 from botocore.config import Config
+from botocore.exceptions import ClientError
 from seq_import.samplesheet import generate_samplesheet
 
 log = logging.getLogger(__name__)
@@ -53,6 +56,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--work-bucket", required=True,
         help="S3 bucket for Nextflow's working directory",
+    )
+    parser.add_argument(
+        "--log-bucket", required=True,
+        help="S3 bucket for publishing .nextflow.log after the run",
     )
     return parser.parse_args(argv)
 
@@ -85,6 +92,26 @@ def build_nextflow_cmd(
     ]
 
 
+def upload_nextflow_log(
+    s3_client, delivery: str, log_bucket: str, log_path: Path = Path("/workflow/.nextflow.log"),
+) -> None:
+    """Upload .nextflow.log to s3://{log_bucket}/basecall-workflow/automated/{delivery}/{ts}/.
+
+    Logged-and-swallowed on failure: a log upload problem should never mask
+    the real exit status of the Nextflow run.
+    """
+    if not log_path.exists():
+        log.warning("No %s to upload", log_path)
+        return
+    timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d_%H%M%S")
+    s3_key = f"basecall-workflow/automated/{delivery}/{timestamp}/.nextflow.log"
+    try:
+        s3_client.upload_file(str(log_path), log_bucket, s3_key)
+        log.info("Uploaded nextflow log to s3://%s/%s", log_bucket, s3_key)
+    except ClientError as e:
+        log.warning("Failed to upload %s: %s", log_path, e)
+
+
 def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -100,10 +127,13 @@ def main() -> None:
         args.work_bucket,
     )
     log.info("Running nextflow: %s", " ".join(nextflow_cmd))
-    subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
+    s3_client = boto3.client("s3", config=Config(max_pool_connections=50))
+    try:
+        subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
+    finally:
+        upload_nextflow_log(s3_client, args.delivery, args.log_bucket)
 
     log.info("Generating samplesheet for delivery %s in bucket %s", args.delivery, args.base_bucket)
-    s3_client = boto3.client("s3", config=Config(max_pool_connections=50))
     output_path = generate_samplesheet(s3_client, args.delivery, bucket=args.base_bucket)
     log.info("Samplesheet written to: %s", output_path)
 

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -96,11 +96,8 @@ def upload_nextflow_log(
 ) -> None:
     """Upload .nextflow.log to s3://{log_bucket}/basecall-workflow/automated/{delivery}/{ts}/.
 
-    Called from a finally block, so we swallow all exceptions: raising on a
-    successful Nextflow run would block samplesheet generation, and raising
-    on a failed Nextflow run would replace the original CalledProcessError
-    with an upload error. The error log surfaces the failure in CloudWatch
-    so a misconfigured IAM/bucket gets noticed.
+    Logs and swallows all upload errors so it is safe to call from a finally block.
+    The error log surfaces the failure in CloudWatch so a misconfigured IAM/bucket gets noticed.
     """
     if not log_path.exists():
         log.warning("No %s to upload", log_path)
@@ -133,6 +130,10 @@ def main() -> None:
     try:
         subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
     finally:
+        # upload_nextflow_log is designed to log-and-swallow all exceptions.
+        # (Because an exception in this finally block would prevent 
+        # samplesheet generation on a successful Nextflow run, or mask CalledProcessError 
+        # from a failed one.)
         upload_nextflow_log(s3_client, args.delivery, args.log_bucket)
 
     log.info("Generating samplesheet for delivery %s in bucket %s", args.delivery, args.base_bucket)

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -74,6 +74,7 @@ def build_nextflow_cmd(
     """
     return [
         "nextflow", "run", "/workflow/main.nf",
+        "-c", "/workflow/configs/basecall.config",
         "-profile", "batch",
         "--nanopore_run", delivery,
         "--kit", kit,

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -97,8 +97,11 @@ def upload_nextflow_log(
 ) -> None:
     """Upload .nextflow.log to s3://{log_bucket}/basecall-workflow/automated/{delivery}/{ts}/.
 
-    Logged-and-swallowed on failure: a log upload problem should never mask
-    the real exit status of the Nextflow run.
+    If the upload fails, log the error and return normally rather than
+    raising. We call this from a finally block before generate_samplesheet,
+    so raising would block samplesheet generation on a successful Nextflow
+    run — worse than losing a log file. The error log surfaces the failure
+    in CloudWatch error metrics so a misconfigured IAM/bucket gets noticed.
     """
     if not log_path.exists():
         log.warning("No %s to upload", log_path)
@@ -109,7 +112,7 @@ def upload_nextflow_log(
         s3_client.upload_file(str(log_path), log_bucket, s3_key)
         log.info("Uploaded nextflow log to s3://%s/%s", log_bucket, s3_key)
     except ClientError as e:
-        log.warning("Failed to upload %s: %s", log_path, e)
+        log.error("Failed to upload %s: %s", log_path, e)
 
 
 def main() -> None:

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 import boto3
 from botocore.config import Config
-from botocore.exceptions import ClientError
 from seq_import.samplesheet import generate_samplesheet
 
 log = logging.getLogger(__name__)
@@ -97,11 +96,11 @@ def upload_nextflow_log(
 ) -> None:
     """Upload .nextflow.log to s3://{log_bucket}/basecall-workflow/automated/{delivery}/{ts}/.
 
-    If the upload fails, log the error and return normally rather than
-    raising. We call this from a finally block before generate_samplesheet,
-    so raising would block samplesheet generation on a successful Nextflow
-    run — worse than losing a log file. The error log surfaces the failure
-    in CloudWatch error metrics so a misconfigured IAM/bucket gets noticed.
+    Called from a finally block, so we swallow all exceptions: raising on a
+    successful Nextflow run would block samplesheet generation, and raising
+    on a failed Nextflow run would replace the original CalledProcessError
+    with an upload error. The error log surfaces the failure in CloudWatch
+    so a misconfigured IAM/bucket gets noticed.
     """
     if not log_path.exists():
         log.warning("No %s to upload", log_path)
@@ -111,8 +110,8 @@ def upload_nextflow_log(
     try:
         s3_client.upload_file(str(log_path), log_bucket, s3_key)
         log.info("Uploaded nextflow log to s3://%s/%s", log_bucket, s3_key)
-    except ClientError as e:
-        log.error("Failed to upload %s: %s", log_path, e)
+    except Exception as e:
+        log.exception("Failed to upload %s: %s", log_path, e)
 
 
 def main() -> None:
@@ -134,13 +133,7 @@ def main() -> None:
     try:
         subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
     finally:
-        # Outer guard so an unexpected upload exception can't replace an
-        # in-flight CalledProcessError from Nextflow. Mirrors the pattern in
-        # mgs-orchestrator's automation/run_automation.py.
-        try:
-            upload_nextflow_log(s3_client, args.delivery, args.log_bucket)
-        except Exception as e:
-            log.exception("Failed to upload .nextflow.log: %s", e)
+        upload_nextflow_log(s3_client, args.delivery, args.log_bucket)
 
     log.info("Generating samplesheet for delivery %s in bucket %s", args.delivery, args.base_bucket)
     output_path = generate_samplesheet(s3_client, args.delivery, bucket=args.base_bucket)

--- a/automation/run_automation.py
+++ b/automation/run_automation.py
@@ -134,7 +134,13 @@ def main() -> None:
     try:
         subprocess.run(nextflow_cmd, check=True, cwd="/workflow")
     finally:
-        upload_nextflow_log(s3_client, args.delivery, args.log_bucket)
+        # Outer guard so an unexpected upload exception can't replace an
+        # in-flight CalledProcessError from Nextflow. Mirrors the pattern in
+        # mgs-orchestrator's automation/run_automation.py.
+        try:
+            upload_nextflow_log(s3_client, args.delivery, args.log_bucket)
+        except Exception as e:
+            log.exception("Failed to upload .nextflow.log: %s", e)
 
     log.info("Generating samplesheet for delivery %s in bucket %s", args.delivery, args.base_bucket)
     output_path = generate_samplesheet(s3_client, args.delivery, bucket=args.base_bucket)


### PR DESCRIPTION
In actually testing out basecalling lambda end-to-end I realized a few pieces of the entrypoint I'd left out--passing the config (absolutely essential for anything to run) and saving the .nextflow.log on S3 (not literally essential, but not having it makes debugging really hard) 

## Summary
- Point the automation entrypoint at the correct `basecall.config` so Nextflow picks up the intended params (`c83803c`).
- Wrap the Nextflow subprocess in a try/finally that uploads `/workflow/.nextflow.log` to `s3://{log_bucket}/basecall-workflow/automated/{delivery}/{ts}/` on both success and failure, so failed Fargate head jobs are debuggable post-mortem instead of losing the log on container teardown (`0d3af8c`). Adds a required `--log-bucket` CLI arg and extends the docker-build smoke test to assert it.

## Caveat — depends on Lambda + IAM changes
The `--log-bucket` flag is required, so this PR is not functional end-to-end until the concurrent changes in `det-terraform-production-role` ship:
- `startOntBasecall` Lambda must append `--log-bucket <bucket>` to `containerOverrides.command`.
- The Batch job role needs `s3:PutObject` on `arn:aws:s3:::<log_bucket>/basecall-workflow/*`.

I'm testing them both (from branches) in tandem and will only merge this when the whole system is working end-to-end.

## Test plan
- [x] CI `Docker Build` passes (the smoke test now asserts `--log-bucket` is listed in the argparse error output).
- [x] After Lambda wiring lands: trigger lambda with a test_event.json (mocking an eventbridge from 1supplemental/barcodes.tsv`), confirm `s3://<log_bucket>/basecall-workflow/automated/<delivery>/<ts>/.nextflow.log` exists once the Batch job terminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)